### PR TITLE
Allow falsey values

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function each (stream, fn, cb) {
     want = false
 
     var data = shift(stream)
-    if (!data) {
+    if (data === null) {
       want = true
       return
     }

--- a/test.js
+++ b/test.js
@@ -80,3 +80,26 @@ tape('each error and callback', function (t) {
     t.end()
   })
 })
+
+tape('each with falsey values', function (t) {
+  var s = through.obj()
+  s.write(0)
+  s.write(false)
+  s.write(undefined)
+  s.end()
+
+  s.on('end', function () {
+    t.end()
+  })
+
+  var expected = [0, false, undefined]
+  var count = 0
+  each(s, function (data, next) {
+    count++
+    t.same(data, expected.shift())
+    next()
+  }, function () {
+    t.same(count, 3)
+  })
+})
+

--- a/test.js
+++ b/test.js
@@ -92,14 +92,14 @@ tape('each with falsey values', function (t) {
     t.end()
   })
 
-  var expected = [0, false, undefined]
+  var expected = [0, false]
   var count = 0
   each(s, function (data, next) {
     count++
     t.same(data, expected.shift())
     next()
   }, function () {
-    t.same(count, 3)
+    t.same(count, 2)
   })
 })
 


### PR DESCRIPTION
I noticed that `0` and `false` were being filtered out, afaik this is a bug, I've changed the check to compare `data === null` instead of `!data`.

Test provided.